### PR TITLE
fix marquee spacing

### DIFF
--- a/src/components/landing/Marquee.jsx
+++ b/src/components/landing/Marquee.jsx
@@ -6,7 +6,7 @@ const Marquee = ({ reverse }) => {
       <div
         className={`${
           reverse ? "animate-marquee-reverse" : "animate-marquee"
-        }  flex justify-evenly w-full gap-8 mx-8`}
+        }  flex justify-evenly w-full`}
       >
         <Review />
         <Review />
@@ -18,7 +18,7 @@ const Marquee = ({ reverse }) => {
           reverse
             ? "animate-marquee-continuation-reverse"
             : "animate-marquee-continuation"
-        } flex justify-between w-full absolute h-full gap-8 mx-8`}
+        } flex justify-between w-full absolute h-full`}
       >
         <Review />
         <Review />

--- a/src/components/landing/Review.jsx
+++ b/src/components/landing/Review.jsx
@@ -4,7 +4,7 @@ import Stars from "./Stars";
 
 const Review = () => {
   return (
-    <div className="flex bg-white rounded-lg p-8 font-outfit">
+    <div className="flex bg-white mx-3 rounded-lg p-8 font-outfit">
       <div className="w-1/4 flex flex-col items-center justify-center">
         <Image src={profile} className="rounded-full w-16" />
         <p className="font-semibold">Bobby Lerias</p>


### PR DESCRIPTION
flexbox has a stroke when trying to calculate gap with marquee animation

<img width="1280" alt="image" src="https://github.com/shahdivyank/r-parts/assets/90938120/d79164ee-5bc4-44a5-8112-f60dae692db1">
